### PR TITLE
Fix installation instructions, add non-SSL capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Clone the git repository and compile the package:
 ```
 $ git clone https://github.com/Altoros/cf-postgresql-broker.git
 $ cd cf-postgresql-broker
-$ make build
 ```
+
 
 Push the compiled binary to the Cloud Foundry:
 ```
@@ -42,6 +42,11 @@ $ cf set-env cf-postgresql-broker PG_SERVICES "$PG_SERVICES"
 
 * `PG_SERVICES` can be customized according to [this go library](https://github.com/pivotal-cf/brokerapi/blob/master/catalog.go#L3)
 * `{GUID}` will be replaced with its runtime value
+
+Optional:  If your PostgreSQL server does not use SSL, disable it:
+```
+$ cf set-env cf-postgresql-broker PGSSLMODE "disable"
+```
 
 Start the application and register a service broker:
 ```$AUTH_PASSWORD

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: cf-postgresql-broker
-  command: ./cf-postgresql-broker
+  command: ./bin/cf-postgresql-broker
   memory: 64M
   buildpack: https://github.com/cloudfoundry/go-buildpack#v1.8.1
   env:


### PR DESCRIPTION
The current instructions say to `make build`, but there is no Makefile.  Using `go build` works if you're on the same architecture, but really the `cf push` should build it on the target architecture.  The go buildpack however puts the executable in the ./bin directory, so the command needs to be changed from `./cf-postgresql-broker` to `./bin/cf-postgresql-broker` in the manifest.

Furthermore, out of the box, this doesn't support non-SSL connections to the PostgreSQL server; I have added some option instructions to the README.md file to assist those who likewise need to make a non-SSL connection.